### PR TITLE
Bugfix

### DIFF
--- a/src/fft-cuda.cu
+++ b/src/fft-cuda.cu
@@ -39,7 +39,7 @@ __global__ void bitrev_reorder(Cplx* __restrict__ r, Cplx* __restrict__ d, int s
  * Inner part of FFT loop. Contains the procedure itself.
  */
 __device__ void inplace_fft_inner(Cplx* __restrict__ r, int j, int k, int m, int n) {
-  if (j + k + m / 2 < n) { 
+  if (j + k + m / 2 < n && k < m / 2) { 
     Cplx t, u;
     
     t.x = __cosf((2.0 * M_PI * k) / (1.0 * m));


### PR DESCRIPTION
Hello, for a university project I got to work on a CUDA implementation of the FFT algorithm, and I had to compare my implementation with some other ones that I could find online, among which I found this one. While working on it, I found a minor bug that basically made too many threads execute on the same data for certain values of the `balance` parameter, thus making the result wrong, so I thought to send a PR to fix it.
Cheers!